### PR TITLE
changed current calculation equations to match new current sensor

### DIFF
--- a/Vehicle/Telemetry_Control_Unit/Telemetry_Control_Unit.ino
+++ b/Vehicle/Telemetry_Control_Unit/Telemetry_Control_Unit.ino
@@ -308,7 +308,7 @@ inline void read_analog_values() {
 void process_mcu_analog_readings() {
     //self derived
     float current_ecu = (filtered_ecu_current_reading/819.2-2.467)/0.4;
-    float current_cooling = (filtered_cooling_current_reading - 2048) / 327.7;
+    float current_cooling = (filtered_cooling_current_reading/819.2-2.49)/0.426;
 
     float glv_voltage_value = (((filtered_supply_reading/4096) * 5) * 55/12) + 0.14; //ADC->12V conversion + offset likely due to resistor values
     //Serial.print("GLV: ");

--- a/Vehicle/Telemetry_Control_Unit/Telemetry_Control_Unit.ino
+++ b/Vehicle/Telemetry_Control_Unit/Telemetry_Control_Unit.ino
@@ -307,10 +307,8 @@ inline void read_analog_values() {
 
 void process_mcu_analog_readings() {
     //self derived
-    float current_ecu = (filtered_ecu_current_reading - 2048) / 151.0;
-    float current_cooling = (filtered_cooling_current_reading - 2048) / 151.0;
-    //Serial.println(current_cooling);
-    //Serial.println(current_ecu);
+    float current_ecu = (filtered_ecu_current_reading/819.2-2.467)/0.4;
+    float current_cooling = (filtered_cooling_current_reading - 2048) / 327.7;
 
     float glv_voltage_value = (((filtered_supply_reading/4096) * 5) * 55/12) + 0.14; //ADC->12V conversion + offset likely due to resistor values
     //Serial.print("GLV: ");


### PR DESCRIPTION
# Pull Request (PR) into Code-2022

## Code Description
Telemetry_Control_Unit.ino was changed, equation for ecu and cooling current now match datasheet for TMCS1101A4 (400mV/A). Added 0.033V offset to ecu current equation during calibration.

## Testing Description
Tested on car on 11/7/21, measured 1.14A from ecu and 2.4A from cooling

## Additional Information
*Put any additional datasheets, information, and/or useful links here.*
[Datasheet](https://www.ti.com/lit/ds/symlink/tmcs1101.pdf?ts=1633545937342&ref_url=https%253A%252F%252Fwww.google.com%252F)

## Checklist
- [ ] Is this code linked to a new board or board rev?
- - [ ] Is *there a PR* for that board in `circuits-2022`? If so, please pause until that PR is merged.
- [x] Did you test the code in real-world conditions before submitting?
- - [ ] Did you *use CPU Speed = 76 Mhz and Optimize = Faster* when testing? 
--No, I used 96Mhz, but it worked and I doubt changing 2 equations would make a difference.
- [x] Did you pull `main` into your branch?
- - [x] Did you *check for merge conflicts*?
- - [x] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
- [x] Did you fill out the above template?
- [x] Did you assign the right people for review (on the right)?
