### PR TITLE
Fix stuck autoparser and console catch exception

### DIFF
--- a/Telemetry/autoparse/app/console.py
+++ b/Telemetry/autoparse/app/console.py
@@ -93,4 +93,9 @@ class Console:
         blanks = '   '
         self.screen.addstr(y,x,blanks)
 
-curses.wrapper(Console().setupScreen)
+try:
+    curses.wrapper(Console().setupScreen)
+except:
+    print("ERROR: Console could not display")
+    print("       Please set your computer resolution to 1920 x XXXX and size to 125%")
+    print("       Press Control + C in Windows or Command + . in Mac to exit")

--- a/Telemetry/autoparse/app/parser.cpp
+++ b/Telemetry/autoparse/app/parser.cpp
@@ -10,6 +10,8 @@
 #include <fstream>
 #include <string>
 
+#define MAGIC_NUMBER 10						// For some reason this is the magic number to advance the cursor when file parsing gets stuck. Other numbers cause segfaults.
+
 void showMenu(char* exe) {
 	puts("\nHyTech SD Parsing System");
 	puts("------------------------");
@@ -117,18 +119,12 @@ void run (FILE* infile) {
 			for (uint8_t *l = data, *r = data + len - 1; l < r; std::swap(*l++, *r--));
 		#endif
 		
-		// AUTOPARSER 0xDE DEBUGGING CHANGES BEGIN HERE
-		//std::cout << std::to_string(ftell(infile)) << std::endl; 	// Debug Statement; Comment out if necessary
+		// "STUCK" AUTOPARSER DEBUGGING CHANGES BEGIN HERE
 		long temp = ftell(infile); 									// temporary variable holding the state of the position of the cursor currently
-		if (last == ftell(infile)) {								// If the cursor has not advanced, add one character to its position and try again
-			fseek(infile, ftell(infile) + 1, SEEK_SET);
-		} else if (id == ID_BMS_BALANCING_STATUS) {					// Else if the ID is 0xDE (the buggy ID), advance the cursor 20 characters to skip the lin
-			if (len == 0) {
-				fseek(infile, ftell(infile) + 20, SEEK_SET); 		
-			}
-		} else {													// Else the cursor position is correct and the line can be parsed
-			parseMessage(id, timeString, data);
+		while (last == ftell(infile)) {								// If the cursor has not advanced, add MAGIC_NUMBER characters to its position and try again
+			fseek(infile, ftell(infile) + MAGIC_NUMBER, SEEK_SET);
 		}
+		parseMessage(id, timeString, data);
 		last = temp;												// Set the tracker from the last iteration
 		//END CHANGES
 


### PR DESCRIPTION
# Pull Request (PR) into Code-2022

## Code Description
Minor fixes to parser.cpp and console.py:
- parser.cpp advances cursor by a magic number of 10 chars when it gets stuck and tries parsing again. 10 just worked, other numbers created segfaults of some kind.
- console.py now has a try-except statement that alerts users to update screen resolution and size if console fails to build because of that reason.

## Testing Description
Small changes, tested locally on laptop and on 10/16 and 6/19 datasets after 0xDE bug was introduced.

## Additional Information

## Checklist
- [ ] Is this code linked to a new board or board rev?
- - [ ] Is *there a PR* for that board in `circuits-2022`? If so, please pause until that PR is merged.
- [ ] Did you test the code in real-world conditions before submitting? **No need bc no vehicle code**
- - [ ] Did you *use CPU Speed = 76 Mhz and Optimize = Faster* when testing?
- [] Did you pull `main` into your branch? **No need bc latest branch off main**
- - [ ] Did you *check for merge conflicts*?
- - [ ] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
- [x] Did you fill out the above template?
- [x] Did you assign the right people for review (on the right)?
