### PR TITLE
Fix parser start time bug

### DIFF
--- a/Telemetry/telemetry_parsers/dataPlots.m
+++ b/Telemetry/telemetry_parsers/dataPlots.m
@@ -216,13 +216,14 @@ mask = adjCurrent>1 & adjVoltage>300;
 adjCurrent(~mask) = [];
 adjVoltage(~mask) = [];
 
-adjCurrent = movmean(adjCurrent, 100000);
-adjVoltage = movmean(adjVoltage, 100000);
+voltageDrop = cat(1, adjCurrent, adjVoltage);
+voltageDrop = round(voltageDrop, 2); % Smooth out, only use two decimal places
 
-adjCurrent = movmean(adjCurrent, 100);
-adjVoltage = movmean(adjVoltage, 100);
+% Credit: https://www.mathworks.com/matlabcentral/answers/151709-how-can-i-average-points-with-just-the-same-x-coordinate
+[uniqueCurrent,~,idx] = unique(voltageDrop(1,:));
+averageVoltage = accumarray(idx,voltageDrop(2,:),[],@mean);
 
-plot(adjCurrent,adjVoltage,'.')
+plot(uniqueCurrent, averageVoltage,'.-')
 xlabel('Current')
 ylabel('Voltage')
 title('Accumulator Voltage Drop Analysis')

--- a/Telemetry/telemetry_parsers/parser.py
+++ b/Telemetry/telemetry_parsers/parser.py
@@ -1171,12 +1171,18 @@ def get_time_elapsed(frames = []):
     '''
     skip = 0
     df_list = []
+    start_time = 0
+    set_start_time = True # boolean flag: we only want to set the start time once, during the first (i.e. earliest) CSV
     try:
         for df in frames:
             skip += 1
             timestamps = [dp.isoparse(x) for x in df['time']]
             if(len(timestamps) != 0):
-                start_time = min(timestamps)
+                
+                if set_start_time:
+                    start_time = min(timestamps)
+                    set_start_time = False # don't set start time again this run
+
                 last_time = -1 # sometimes the Teensy has a slight ms miscue where it jumps back 1 sec on a second change, we must address it here
                 time_delta = []
                 for x in timestamps:


### PR DESCRIPTION
# Pull Request (PR) into Code-2022

## Code Description
parser.py start time fix for each CSV - basically what happened was the start time was being reset at each CSV, so the data would restart from 0 instead of continuing when we moved from CSV to CSV. Also smoothed out accumulator voltage drop analysis in the plotter.

## Testing Description
Complete 3/6/2022 test data.

## Additional Information
*Put any additional datasheets, information, and/or useful links here.*

## Checklist
- [ ] Is this code linked to a new board or board rev?
- - [ ] Is *there a PR* for that board in `circuits-2022`? If so, please pause until that PR is merged.
- [ ] If you made a change or addition or deletion to the CAN library, did you inform the Data Aq lead?
- [ ] Did you test the code in real-world conditions before submitting?
- - [ ] Did you *use CPU Speed = 720 MHz (overclock) and Optimize = Fastest* when testing with Teensy 4.x?
- - [ ] Did you *use CPU Speed = 144 MHz (overclock) and Optimize = Fastest with LTO* when testing with Teensy 3.5?
- - [ ] Did you *use CPU Speed = 120 MHz (overclock) and Optimize = Fastest with LTO* when testing with Teensy 3.2?
- - [ ] Did you *use Teensyduino 1.56 with Arduino 1.8.19* when testing with the latest libraries from `main`?
- [ ] Did you pull `main` into your branch?
- - [ ] Did you *check for merge conflicts*?
- - [ ] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
- [x] Did you fill out the above template?
- [x] Did you assign the right people for review (on the right)?
